### PR TITLE
TECH - Allow test usage with jest and mocha

### DIFF
--- a/lib/rules/metrics-definition.js
+++ b/lib/rules/metrics-definition.js
@@ -36,15 +36,21 @@ module.exports = {
 
         return {
             MemberExpression: function(node) {
-                if( node.object &&
+                if (node.object &&
                     (node.object.name === 'metrics' || node.object.name === 'metric')
                 ) {
                     if (node.property && node.property.name === 'increment') {
                         if (node.parent.type !== 'CallExpression') {
-                          context.report(node, 'metrics.increment can only be called');
+                            // We allow the test properties usage, nothing more
+                            if (!node.parent.property ||
+                                (node.parent.property &&
+                                !['args', 'mock'].includes(node.parent.property.name))) {
+                                context.report(node, 'metrics.increment can only be called');
+                            }
+
                           return;
                         }
-                        const args = node.parent.arguments
+                        const args = node.parent.arguments;
                         if (args.length !== 1) {
                             context.report(node, 'Only a single argument is accepted on metrics.increment.');
                         }

--- a/lib/rules/metrics-definition.js
+++ b/lib/rules/metrics-definition.js
@@ -41,7 +41,13 @@ module.exports = {
                 ) {
                     if (node.property && node.property.name === 'increment') {
                         if (node.parent.type !== 'CallExpression') {
-                            // We allow the test properties usage, nothing more
+                            /**
+                             * If a property exists, we do an exception only for the test
+                             * Otherwise, same behavior, it must be a function
+                             * -> "args" is used by mocha
+                             * -> "mock.calls" is used by jest
+                             * For example: "metrics.increment.args" "metrics.increment.mock.calls"
+                             */
                             if (!node.parent.property ||
                                 (node.parent.property &&
                                 !['args', 'mock'].includes(node.parent.property.name))) {

--- a/lib/rules/metrics-documentation.js
+++ b/lib/rules/metrics-documentation.js
@@ -40,11 +40,12 @@ module.exports = {
 
         return {
             MemberExpression: function(node) {
-                if( node.object &&
+                if (node.object &&
                     (node.object.name === 'metrics' || node.object.name === 'metric') &&
-                    node.property && node.property.name === 'increment'
+                    node.property && node.property.name === 'increment' &&
+                    node.parent.arguments
                 ) {
-                    const args = node.parent.arguments
+                    const args = node.parent.arguments;
                     const metric = args[0].value;
                     const parent = node.parent.parent;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-metrics",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Check metrics definition",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-metrics",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Check metrics definition",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/metrics-definition.js
+++ b/tests/lib/rules/metrics-definition.js
@@ -22,7 +22,9 @@ ruleTester.run("metrics-definition", rule, {
 
     valid: [
         'metric.increment("test.eslint")',
-        'metrics.increment("test.eslint")'
+        'metrics.increment("test.eslint")',
+        'metrics.increment.args',
+        'metrics.increment.mock',
     ],
 
     invalid: [
@@ -41,11 +43,19 @@ ruleTester.run("metrics-definition", rule, {
             }]
         },
         {
-          code: 'var x = metrics.increment;',
+          code: 'var x = metrics.increment.somethingWrong;',
           errors: [{
                 message: 'metrics.increment can only be called',
                 type: ''
           }]
+        },
+        {
+            code: 'var x = metrics.increment;',
+            errors: [{
+                message: 'metrics.increment can only be called',
+                type: ''
+            }]
         }
     ]
 });
+


### PR DESCRIPTION
**Context:**

The linter issue happens during testing. If we name an object the same as the library `metric(s)`, we must follow the rule of the linter. Otherwise, if you name it, let's say `metricsIncrementSpy` as you use to, you will be ok.

So during mocha or jest test, if I use my object like this:
```
expect(metrics.increment.args)
expect(metrics.increment.mock.calls)
```

I get 2 errors:
- Node arguments not available, https://github.com/transcovo/eslint-plugin-metrics/blob/60bcba5f28017091a864caf2f208316daf5feb34/lib/rules/metrics-documentation.js#L49
- A report from eslint from here https://github.com/transcovo/eslint-plugin-metrics/blob/458ac7a558b5d37095bb8eb34dc90f1f0f842905/lib/rules/metrics-definition.js#L54

(I had to read the Mozilla (parsing) documentation to understand why).

-----

**More info:**

My metrics object during mocha test
```js
const metrics = {
    increment: sandbox.stub()
  };
```

And use it normally after having injected it in my service and call a method:

```js
expect(metrics.increment.args).to.deep.equal([
        ['metric_name']
      ]);
```

In my case, the linter throws the error from `parent.node.arguments` (see above) as it's not available in this specific case. 

It took me a while to figure out what was wrong in my code as the error was not explicit. So I decided to make an exception for `args` and `mock` during the test with `mocha`  and `jest`
